### PR TITLE
Fix Events Inserts: possibly causing lockouts to not work.

### DIFF
--- a/backend/controllers/userAuthController.js
+++ b/backend/controllers/userAuthController.js
@@ -392,6 +392,8 @@ export const refreshAccessToken = async (req, res) => {
 
 
 // Logout the user 
+// clears the referesh token.
+// access token remains active till expiration.
 export const logout = async (req, res) => {
 
   try {
@@ -470,7 +472,7 @@ export const updatePassword = async (req, res, next) => {
       parallelism: 1
     });
 
-    // Mark oldpassowrd as not current
+    // Mark old passowrd as not current
     await pool.query("BEGIN")
 
     await pool.query(

--- a/backend/database/ddl_02.sql
+++ b/backend/database/ddl_02.sql
@@ -119,6 +119,18 @@ CREATE TABLE IF NOT EXISTS transactions (
 INSERT INTO accounts (userid, name, type, balance)
 VALUES (NULL, 'SYS_ACC', 'checking', 0.00);
 
+-- Events are recorded in userevents. 
+-- Events must be initialized first so triggers can find the event ID to record actions.
+INSERT INTO events (event)
+VALUES
+('Account Created'),
+('Successful Authentication'),
+('Failed Authentication'),
+('Account Locked'),
+('Account Unlocked'),
+('Log Out'),
+('Password Updated');
+
 --################# START DEFINE INDEXES #################
 
 --Fast lookup for a users current password:

--- a/backend/database/dml_02.sql
+++ b/backend/database/dml_02.sql
@@ -4,21 +4,6 @@ Includes: Users, Accounts, Transactions
 */
 
 -- ============================================
--- EVENT SEEDS
--- ============================================
--- Events are recorded in user events. 
--- Events must be initialized first so triggers can find the event ID to record actions.
-INSERT INTO events (event)
-VALUES
-('Account Created'),
-('Successful Authentication'),
-('Failed Authentication'),
-('Account Locked'),
-('Account Unlocked'),
-('Log Out'),
-('Password Updated');
-
--- ============================================
 -- USERS SEED
 -- ============================================
 -- Passwords here are plain text for example purposes.


### PR DESCRIPTION
# fix events inserts
## issue
- events table was empty on the prod server.
- logging and lockouts relies on the prepopulation of records in the events table.
## fix
- moved the event inserts from the dml to the ddl.
### other
- left the seed data in the dml for other tables.
- this information does not seem to get uploaded to the prod server.
- it remains useful for local testing.